### PR TITLE
Api refactor

### DIFF
--- a/bc-api-client/src/lib.rs
+++ b/bc-api-client/src/lib.rs
@@ -9,10 +9,9 @@ pub mod request;
 pub mod response;
 
 use auth::Auth;
-use request::Request;
 
 pub use reqwest;
-use reqwest::{Client, Method};
+use reqwest::{Client, Method, RequestBuilder};
 
 use std::marker::PhantomData;
 use std::sync::Arc;
@@ -113,40 +112,33 @@ impl<T> ApiClient<T> {
         }
     }
 
-    #[must_use]
-    pub fn request(self, method: Method, route: &str) -> Request {
+    pub fn request(self, method: Method, route: &str) -> RequestBuilder {
         let url = format!("{}{}", self.base_url, route);
         let request = self.client.request(method, url);
-        self.auth.attach(request).into()
+        self.auth.attach(request)
     }
 
-    #[must_use]
-    pub fn get(self, route: &str) -> Request {
+    pub fn get(self, route: &str) -> RequestBuilder {
         self.request(Method::GET, route)
     }
 
-    #[must_use]
-    pub fn post(self, route: &str) -> Request {
+    pub fn post(self, route: &str) -> RequestBuilder {
         self.request(Method::POST, route)
     }
 
-    #[must_use]
-    pub fn put(self, route: &str) -> Request {
+    pub fn put(self, route: &str) -> RequestBuilder {
         self.request(Method::PUT, route)
     }
 
-    #[must_use]
-    pub fn patch(self, route: &str) -> Request {
+    pub fn patch(self, route: &str) -> RequestBuilder {
         self.request(Method::PATCH, route)
     }
 
-    #[must_use]
-    pub fn delete(self, route: &str) -> Request {
+    pub fn delete(self, route: &str) -> RequestBuilder {
         self.request(Method::DELETE, route)
     }
 
-    #[must_use]
-    pub fn head(self, route: &str) -> Request {
+    pub fn head(self, route: &str) -> RequestBuilder {
         self.request(Method::HEAD, route)
     }
 }

--- a/bc-api-client/src/request.rs
+++ b/bc-api-client/src/request.rs
@@ -29,7 +29,7 @@ impl From<RequestBuilder> for Request {
 
 impl From<Request> for RequestBuilder {
     fn from(request: Request) -> Self {
-        request.0
+        request.into_inner()
     }
 }
 
@@ -54,5 +54,9 @@ impl Request {
             body: e.to_string(),
         })?;
         (status, message).try_into()
+    }
+
+    pub fn into_inner(self) -> RequestBuilder {
+        self.0
     }
 }

--- a/bc-api-client/src/request.rs
+++ b/bc-api-client/src/request.rs
@@ -2,6 +2,7 @@ use crate::response::{Response, Result};
 use reqwest::{RequestBuilder, StatusCode};
 use serde::de::DeserializeOwned;
 
+/*
 use std::ops::{Deref, DerefMut};
 
 #[derive(Debug)]
@@ -32,8 +33,10 @@ impl From<Request> for RequestBuilder {
         request.into_inner()
     }
 }
+*/
 
-impl Request {
+#[allow(async_fn_in_trait)]
+pub trait Request {
     /// Dispatches an API call and attempts to deserialize the response payload to a generic type
     /// `R` that is specified at compile time.
     ///
@@ -43,8 +46,12 @@ impl Request {
     /// # Errors
     ///
     /// Throws an error if the request fails to send or if the response cannot be processed.
-    pub async fn dispatch<R: DeserializeOwned>(self) -> Result<R> {
-        let response = self.0.send().await.map_err(|e| Response {
+    async fn dispatch<R: DeserializeOwned>(self) -> Result<R>;
+}
+
+impl Request for RequestBuilder {
+    async fn dispatch<R: DeserializeOwned>(self) -> Result<R> {
+        let response = self.send().await.map_err(|e| Response {
             status: e.status().unwrap_or(StatusCode::BAD_REQUEST),
             body: e.to_string(),
         })?;
@@ -54,9 +61,5 @@ impl Request {
             body: e.to_string(),
         })?;
         (status, message).try_into()
-    }
-
-    pub fn into_inner(self) -> RequestBuilder {
-        self.0
     }
 }


### PR DESCRIPTION
# Description
- `ApiClient` can now be initialized using the builder pattern.
- `Request` is now a trait instead of a wrapper type around `RequestBuilder` because it is cleaner to use it this way, essentially when the raw `RequestBuilder` is used (e.g. attaching json payload using `.json`
