### PR TITLE
Rename path to route as its more accurate.

### DIFF
--- a/bc-utils/src/lib.rs
+++ b/bc-utils/src/lib.rs
@@ -8,22 +8,22 @@ pub use bc_utils_derive::SerdeAsString;
 /// `FromStr`.
 pub trait SerdeAsString: std::str::FromStr + std::fmt::Display {}
 
-/// Fills an URL path with input values by matching the respective input keys to patterns in the URL
-/// string.
+/// Fills an URL path (route) with input values by matching the respective input keys to patterns
+/// in the URL string.
 ///
-/// The input keys (variable names) must match the key in the path. Furthermore, the key's type must
+/// The input keys (variable names) must match the key in the route. Furthermore, the key's type must
 /// implement `ToString`.
 ///
 /// # Examples
 ///
 /// ```
-/// # use bc_utils::fill_path;
+/// # use bc_utils::fill_route;
 /// // no change, no input pattern present
-/// assert_eq!(fill_path!(":{}", "/v1/id"), "/v1/id");
+/// assert_eq!(fill_route!(":{}", "/v1/id"), "/v1/id");
 ///
 /// let my_id = 123;
 /// // 'my_id' replaced with its stringified value
-/// assert_eq!(fill_path!(":{}", "/v1/id/:my_id", my_id), "/v1/id/123");
+/// assert_eq!(fill_route!(":{}", "/v1/id/:my_id", my_id), "/v1/id/123");
 ///
 /// let my_id = 123;
 /// let your_id = 777;
@@ -31,16 +31,16 @@ pub trait SerdeAsString: std::str::FromStr + std::fmt::Display {}
 /// // all ids replaced with their stringified value
 /// // note the different formatting option
 /// assert_eq!(
-///     fill_path!("<{}>", "/v1/id/<my_id>/range/<your_id>:<their_id>", my_id, your_id, their_id),
+///     fill_route!("<{}>", "/v1/id/<my_id>/range/<your_id>:<their_id>", my_id, your_id, their_id),
 ///     "/v1/id/123/range/777:999"
 /// );
 /// ```
 #[macro_export]
-macro_rules! fill_path {
-    ($pattern:literal, $path:expr $(, $key:ident)*) => {
+macro_rules! fill_route {
+    ($pattern:literal, $route:expr $(, $key:ident)*) => {
         {
             #[allow(unused_mut)]
-            let mut result = $path.to_string(); // with no input keys, mut is unused
+            let mut result = $route.to_string(); // with no input keys, mut is unused
             $(
                 let replacement = &$key.to_string();
                 result = result.replace(&format!($pattern, stringify!($key)), replacement);
@@ -52,30 +52,30 @@ macro_rules! fill_path {
 
 /// Fills an URL with values matching `{}` patterns within the original string.
 ///
-/// URLs of the form `/foo/{bar}/baz/{quux}` are used by `actix-web` and `axum ^0.8` web frameworks
+/// URLs of the form `/foo/{bar}/baz/{quux}` are used by `actix-web` and `axum` ^0.8 web frameworks
 /// to match input routes.
 ///
 /// # Examples
 ///
 /// ```
-/// # use bc_utils::path;
+/// # use bc_utils::route;
 /// let simple = "/v1/id";
 /// let complex = "/hello/{a}/bello/{b}/{c}:{d}/asd";
 /// let a = 1234u16;
 /// let b = "yello";
 /// let c = 111u64;
 /// let d = 222u64;
-/// assert_eq!(path!(simple), "/v1/id");
+/// assert_eq!(route!(simple), "/v1/id");
 /// assert_eq!(
-///     path!(complex, a, b, c, d),
+///     route!(complex, a, b, c, d),
 ///     "/hello/1234/bello/yello/111:222/asd"
 /// );
 ///
 /// ```
 #[macro_export]
-macro_rules! path {
-    ($path:expr $(, $key:ident)*) => {
-        $crate::fill_path!("{{{}}}", $path $(, $key)*)
+macro_rules! route {
+    ($route:expr $(, $key:ident)*) => {
+        $crate::fill_route!("{{{}}}", $route $(, $key)*)
     };
 }
 


### PR DESCRIPTION
# Description
`route!` is a better indicator of functionality than `path!`.