### PR TITLE
Cleaned up error handling.

### DIFF
--- a/bc-api-client/Cargo.toml
+++ b/bc-api-client/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1" }
+thiserror = { version = "1" }

--- a/bc-api-client/src/error.rs
+++ b/bc-api-client/src/error.rs
@@ -1,25 +1,13 @@
-use serde::{Deserialize, Serialize};
+use thiserror::Error as ErrorT;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct GenericError {
-    pub error: String,
-    pub message: String,
-}
+use std::error::Error as StdError;
 
-impl GenericError {
-    #[allow(clippy::needless_pass_by_value)]
-    #[must_use]
-    pub fn new<E: ToString>(error: E) -> Self {
-        Self {
-            error: error.to_string(),
-            message: String::new(),
-        }
-    }
-
-    #[allow(clippy::needless_pass_by_value)]
-    #[must_use]
-    pub fn with_message<M: ToString>(mut self, message: M) -> Self {
-        self.message = message.to_string();
-        self
-    }
+#[derive(ErrorT, Debug)]
+pub enum Error {
+    #[error(transparent)]
+    Client(#[from] reqwest::Error),
+    #[error(transparent)]
+    Decode(#[from] serde_json::Error),
+    #[error("an unexpecte error occurred: {0}")]
+    Unexpected(Box<dyn StdError + Send + Sync>),
 }

--- a/bc-api-client/src/lib.rs
+++ b/bc-api-client/src/lib.rs
@@ -17,7 +17,7 @@ use reqwest::{Client, Method, RequestBuilder};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-pub type ApiResult<T> = Result<response::Response<T>, response::Response<error::GenericError>>;
+pub type ApiResult<T> = Result<response::Response<T>, error::Error>;
 
 #[must_use]
 pub struct ApiClientBuilder<'a> {

--- a/bc-api-client/src/response.rs
+++ b/bc-api-client/src/response.rs
@@ -1,5 +1,4 @@
 use crate::ApiResult;
-use crate::error::GenericError;
 use reqwest::StatusCode;
 use serde::de::DeserializeOwned;
 
@@ -24,12 +23,12 @@ impl<R: Default> Default for Response<R> {
 
 impl Response<Vec<u8>> {
     #[must_use]
-    pub fn empty(self) -> Response<()> {
+    pub fn into_empty(self) -> Response<()> {
         self.with_body(())
     }
 
     #[must_use]
-    pub fn text(self) -> Response<String> {
+    pub fn into_text(self) -> Response<String> {
         let body = self.body_to_utf8();
         self.with_body(body)
     }
@@ -43,17 +42,15 @@ impl Response<Vec<u8>> {
     /// # Errors
     ///
     /// Returns an error if the response status is error or if deserialization fails.
-    pub fn json<R: DeserializeOwned>(self) -> ApiResult<R> {
-        match serde_json::from_slice(&self.body) {
-            Ok(body) => Ok(self.with_body(body)),
-            Err(error) => Err(self.text().bad_request(error.to_string())),
-        }
+    pub fn try_into_json<R: DeserializeOwned>(self) -> ApiResult<R> {
+        let body = serde_json::from_slice(&self.body)?;
+        Ok(self.with_body(body))
     }
 }
 
 impl Response<()> {
     #[must_use]
-    pub fn new() -> Self {
+    pub fn empty() -> Self {
         Self::default()
     }
 }
@@ -84,24 +81,6 @@ impl<R> Response<R> {
     }
 }
 
-impl<R: std::fmt::Debug> Response<R> {
-    #[must_use]
-    pub fn bad_request<E: ToString>(self, error: E) -> Response<GenericError> {
-        self.error(StatusCode::BAD_REQUEST, error)
-    }
-
-    #[allow(clippy::needless_pass_by_value)]
-    #[must_use]
-    pub fn error<E: ToString>(self, status: StatusCode, error: E) -> Response<GenericError> {
-        let message = format!("{:#?}", self.body);
-        let response = self
-            .with_status(status)
-            .with_body(GenericError::new(error.to_string()).with_message(message));
-        debug_assert!(response.is_error());
-        response
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -122,7 +101,7 @@ mod test {
         let mut headers = HashMap::new();
         headers.insert("foo".to_string(), "bar".to_string());
 
-        let response = Response::new().with_headers(headers);
+        let response = Response::empty().with_headers(headers);
         assert_eq!(response.status, status);
         assert_eq!(response.headers.get("foo").unwrap(), "bar");
         assert_eq!(response.body, ());
@@ -131,23 +110,23 @@ mod test {
     #[test]
     fn process_string() {
         let input = "hello world";
-        let response = Response::new().with_body(input);
+        let response = Response::empty().with_body(input);
         assert_eq!(response.body, input);
 
         let input = "hello \nmy\" world";
         let status = StatusCode::ACCEPTED;
-        let response = Response::new()
+        let response = Response::empty()
             .with_status(status)
             .with_body(input.as_bytes().to_vec())
-            .text();
+            .into_text();
         assert_eq!(response.status, status);
         assert_eq!(response.body, input);
 
         let input = "hello \nmy\" world";
         let input_json_bytes = json!(input).to_string().as_bytes().to_vec();
-        let response = Response::new()
+        let response = Response::empty()
             .with_body(input_json_bytes)
-            .json::<String>()
+            .try_into_json::<String>()
             .unwrap();
         assert_eq!(response.body, input);
     }
@@ -157,32 +136,32 @@ mod test {
         let status = StatusCode::NO_CONTENT;
         let input = 1234;
         let input_json_bytes = json!(input).to_string().as_bytes().to_vec();
-        let response = Response::new()
+        let response = Response::empty()
             .with_status(status)
             .with_body(input_json_bytes)
-            .json::<u16>()
+            .try_into_json::<u16>()
             .unwrap();
         assert_eq!(response.status, status);
         assert_eq!(response.body, input);
 
         let input = vec![1, 2, 3, 4];
         let input_json_bytes = json!(input).to_string().as_bytes().to_vec();
-        let response = Response::new()
+        let response = Response::empty()
             .with_body(input_json_bytes)
-            .json::<Vec<u64>>()
+            .try_into_json::<Vec<u64>>()
             .unwrap();
         assert_eq!(response.body, input);
     }
 
     #[test]
-    fn process_valid_body() {
+    fn process_valid_json() {
         let input_json_bytes = json!({ "foo": 12, "bar": "mybar" })
             .to_string()
             .as_bytes()
             .to_vec();
-        let response = Response::new()
+        let response = Response::empty()
             .with_body(input_json_bytes)
-            .json::<TestData>()
+            .try_into_json::<TestData>()
             .unwrap();
         assert_eq!(
             response.body,
@@ -195,26 +174,24 @@ mod test {
     }
 
     #[test]
-    fn process_invalid_body() {
+    fn process_invalid_json() {
         let input_json_bytes = json!({ "foo": "12", "bar": "mybar" })
             .to_string()
             .as_bytes()
             .to_vec();
-        let response = Response::new()
-            .with_body(input_json_bytes)
-            .json::<TestData>()
-            .unwrap_err();
-        assert_eq!(response.status, StatusCode::BAD_REQUEST);
+        assert!(
+            Response::empty()
+                .with_body(input_json_bytes)
+                .try_into_json::<TestData>()
+                .is_err()
+        );
     }
 
     #[test]
     fn process_error() {
         let status = StatusCode::IM_A_TEAPOT;
 
-        let error = format!("request failed with status {status}");
-        let response = Response::new().error(status, &error);
+        let response = Response::empty().with_status(status);
         assert!(response.is_error());
-        assert_eq!(response.status, status);
-        assert_eq!(response.body, GenericError::new(error).with_message("()"));
     }
 }


### PR DESCRIPTION
# Description
Returning `Response` types as error was cumbersome, cleaned up with custom `Error` type.